### PR TITLE
Add `asset-generation-support`

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -1,6 +1,7 @@
 name: Publish to GitHub Pages
 
-on: [push, workflow_dispatch]
+on:
+  workflow_dispatch:
 
 permissions:
   packages: read
@@ -34,6 +35,7 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: ./dist
+
   publish:
     runs-on: [self-hosted, ubuntu-latest, x64, linux]
     needs: build
@@ -44,4 +46,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
-

--- a/satis.json
+++ b/satis.json
@@ -6,7 +6,8 @@
     { "type": "vcs", "url": "https://github.com/yourparkingspace/cranium-php" },
     { "type": "vcs", "url": "https://github.com/yourparkingspace/microservice-connect-php" },
     { "type": "vcs", "url": "https://github.com/yourparkingspace/code-standards-laravel" },
-    { "type": "vcs", "url": "https://github.com/yourparkingspace/products-support" }
+    { "type": "vcs", "url": "https://github.com/yourparkingspace/products-support" },
+    { "type": "vcs", "url": "https://github.com/yourparkingspace/asset-generation-support" }
   ],
   "require-all": true
 }


### PR DESCRIPTION
This support package will contain DTOs to read/write data files for combining with templates in the asset generation service.

It will include some more helpers in future. It will be included by asset generation service and other services that require assets to be generated (first service will likely be products to generate confirmation PDFs from markup given by 3rd party API).