### PR TITLE
BE-616: Update workflow

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -15,7 +15,30 @@ jobs:
     environment: actions
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Get OS
+        id: os
+        run: |
+          df -h
+          if [ -n "$(command -v apt-get)" ]; then
+              echo "os=ubuntu" >> "$GITHUB_OUTPUT"
+              echo "Using Ubuntu"
+          else
+              echo "os=linux" >> "$GITHUB_OUTPUT"
+              echo "Using Linux"
+          fi
+
+      - name: Wait for no dpkg lock
+        shell: bash
+        run: |
+          if [ "${{ steps.os.outputs.os }}" = "ubuntu" ]; then
+            # Check for dpkg lock and wait if necessary
+            while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
+              echo "Waiting for other software managers to finish..."
+              sleep 5
+            done
+          fi
+
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@verbose
@@ -32,7 +55,7 @@ jobs:
           COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.BOT_TOKEN }}"} }'
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
 
@@ -45,4 +68,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Updates deprecated actions that use node16:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

And add check for unattended upgrades that seems to be handled poorly by setup php action

<img width="1241" alt="image" src="https://github.com/yourparkingspace/satis/assets/5834879/146b0169-e5f6-4a45-b2eb-009b56ec8e8c">
