### PR TITLE
Adds laravel-resourceful for Parkmaven.

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -17,6 +17,7 @@
     { "type": "vcs", "url": "https://github.com/yourparkingspace/hookable" },
     { "type": "vcs", "url": "https://github.com/yourparkingspace/getaddress.git" },
     { "type": "vcs", "url": "https://github.com/yourparkingspace/laravel-rollout.git" }
+    { "type": "vcs", "url": "https://github.com/yourparkingspace/laravel-resourceful.git" }
   ],
   "require-all": true
 }


### PR DESCRIPTION
Parkmaven needs to be able to pull private repositories from Github. This change is to start mirroring them with Satis.